### PR TITLE
Add setBackgroundSystemUiVisibility in builders support

### DIFF
--- a/powermenu/src/main/java/com/skydoves/powermenu/AbstractMenuBuilder.java
+++ b/powermenu/src/main/java/com/skydoves/powermenu/AbstractMenuBuilder.java
@@ -49,6 +49,7 @@ public abstract class AbstractMenuBuilder {
   protected Drawable divider = null;
   protected int backgroundColor = Color.BLACK;
   protected float backgroundAlpha = 0.6f;
+  protected int backgroundSystemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE;
   protected boolean focusable = false;
   protected int selected = -1;
   protected boolean isClipping = true;

--- a/powermenu/src/main/java/com/skydoves/powermenu/AbstractPowerMenu.java
+++ b/powermenu/src/main/java/com/skydoves/powermenu/AbstractPowerMenu.java
@@ -142,6 +142,7 @@ public abstract class AbstractPowerMenu<E, T extends MenuBaseAdapter>
     setMenuShadow(builder.menuShadow);
     setBackgroundColor(builder.backgroundColor);
     setBackgroundAlpha(builder.backgroundAlpha);
+    setBackgroundSystemUiVisibility(builder.backgroundSystemUiVisibility);
     setFocusable(builder.focusable);
     setIsClipping(builder.isClipping);
     setAutoDismiss(builder.autoDismiss);
@@ -869,6 +870,15 @@ public abstract class AbstractPowerMenu<E, T extends MenuBaseAdapter>
    */
   public void setBackgroundAlpha(float alpha) {
     backgroundView.setAlpha(alpha);
+  }
+
+  /**
+   * sets system UI visibility flags for {@link #backgroundView}.
+   *
+   * @param visibility visibility value.
+   */
+  public void setBackgroundSystemUiVisibility(int visibility) {
+    backgroundView.setSystemUiVisibility(visibility);
   }
 
   /**

--- a/powermenu/src/main/java/com/skydoves/powermenu/CustomPowerMenu.java
+++ b/powermenu/src/main/java/com/skydoves/powermenu/CustomPowerMenu.java
@@ -315,6 +315,17 @@ public class CustomPowerMenu<T, E extends MenuBaseAdapter<T>> extends AbstractPo
     }
 
     /**
+     * sets the system UI visibility of the background popup.
+     *
+     * @param visibility system UI visibility of the background popup.
+     * @return {@link Builder}.
+     */
+    public Builder setBackgroundSystemUiVisibility(int visibility) {
+      this.backgroundSystemUiVisibility = visibility;
+      return this;
+    }
+
+    /**
      * sets the focusability of the popup menu.
      *
      * @param focusable focusability of the popup menu.

--- a/powermenu/src/main/java/com/skydoves/powermenu/PowerMenu.java
+++ b/powermenu/src/main/java/com/skydoves/powermenu/PowerMenu.java
@@ -507,6 +507,17 @@ public class PowerMenu extends AbstractPowerMenu<PowerMenuItem, MenuListAdapter>
     }
 
     /**
+     * sets the system UI visibility of the background popup.
+     *
+     * @param visibility system UI visibility of the background popup.
+     * @return {@link Builder}.
+     */
+    public Builder setBackgroundSystemUiVisibility(int visibility) {
+      this.backgroundSystemUiVisibility = visibility;
+      return this;
+    }
+
+    /**
      * sets the focusability of the popup menu.
      *
      * @param focusable focusability of the popup menu.


### PR DESCRIPTION
### Types of changes

- [x] New feature (non-breaking change which adds functionality)

👋 Addresses issue #53 by adding support for custom system UI visibility flags for the background view.

The default is `View.SYSTEM_UI_FLAG_VISIBLE` with value: `0`

If users of this library use custom visibility flags on their views, they can fix it by passing the same flags down to PowerMenu.

For example:

```java
@Override
protected void onCreate(Bundle savedInstanceState) {
  super.onCreate(savedInstanceState);
  int visibility = View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
                 | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
                 | View.SYSTEM_UI_FLAG_FULLSCREEN
                 | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
                 | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
                 | View.SYSTEM_UI_FLAG_LAYOUT_STABLE;
  getWindow().getDecorView().setSystemUiVisibility(visibility);
  setContentView(R.layout.activity_main);

  new PowerMenu.Builder(this)
    ...
    .setBackgroundSystemUiVisibility(getWindow().getDecorView().getSystemUiVisibility())
    ...
    .build();
}
```