### PR TITLE
Allow stroke through MaterialCardView styling

### DIFF
--- a/app/src/main/java/com/skydoves/powermenudemo/PowerMenuUtils.java
+++ b/app/src/main/java/com/skydoves/powermenudemo/PowerMenuUtils.java
@@ -21,7 +21,9 @@ import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
 import android.view.Gravity;
+import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.core.content.ContextCompat;
+import androidx.core.content.res.ResourcesCompat;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
 import com.skydoves.powermenu.CircularEffect;
@@ -135,7 +137,9 @@ public class PowerMenuUtils {
       LifecycleOwner lifecycleOwner,
       OnMenuItemClickListener<PowerMenuItem> onMenuItemClickListener) {
 
-    return new PowerMenu.Builder(context)
+    Context styledContext = new ContextThemeWrapper(context, R.style.PopupCardThemeOverlay);
+
+    return new PowerMenu.Builder(styledContext)
         .addItem(new PowerMenuItem("WeChat", R.drawable.ic_wechat))
         .addItem(new PowerMenuItem("Facebook", R.drawable.ic_facebook))
         .addItem(new PowerMenuItem("Twitter", R.drawable.ic_twitter))
@@ -144,8 +148,8 @@ public class PowerMenuUtils {
         .setLifecycleOwner(lifecycleOwner)
         .setOnMenuItemClickListener(onMenuItemClickListener)
         .setAnimation(MenuAnimation.FADE)
-        .setMenuRadius(10f)
-        .setMenuShadow(10f)
+        .setMenuRadius(context.getResources().getDimensionPixelSize(R.dimen.menu_corner_radius))
+        .setMenuShadow(context.getResources().getDimensionPixelSize(R.dimen.menu_elevation))
         .build();
   }
 

--- a/app/src/main/java/com/skydoves/powermenudemo/PowerMenuUtils.java
+++ b/app/src/main/java/com/skydoves/powermenudemo/PowerMenuUtils.java
@@ -23,7 +23,6 @@ import android.graphics.drawable.ColorDrawable;
 import android.view.Gravity;
 import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.core.content.ContextCompat;
-import androidx.core.content.res.ResourcesCompat;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
 import com.skydoves.powermenu.CircularEffect;

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="menu_corner_radius">24dp</dimen>
+    <dimen name="menu_elevation">8dp</dimen>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
 
-  <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+  <style name="AppTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccent</item>
@@ -10,6 +10,15 @@
   <style name="CircleImageStyle" parent="">
     <item name="cornerFamily">rounded</item>
     <item name="cornerSize">50%</item>
+  </style>
+
+  <style name="PopupCardStyle" parent="Widget.MaterialComponents.CardView">
+    <item name="strokeColor">#00F</item>
+    <item name="strokeWidth">5dp</item>
+  </style>
+
+  <style name="PopupCardThemeOverlay">
+    <item name="materialCardViewStyle">@style/PopupCardStyle</item>
   </style>
 
 </resources>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -13,7 +13,5 @@ ext.versions = [
     androidxAppcompat: '1.3.0-alpha01',
     cardView         : '1.0.0',
     lifecycle        : '2.2.0',
-
-    // for demo
     googleMaterial   : '1.3.0-alpha01',
 ]

--- a/powermenu/build.gradle
+++ b/powermenu/build.gradle
@@ -20,6 +20,7 @@ android {
 dependencies {
     implementation "androidx.appcompat:appcompat:$versions.androidxAppcompat"
     implementation "androidx.cardview:cardview:$versions.cardView"
+    implementation "com.google.android.material:material:$versions.googleMaterial"
     implementation "androidx.lifecycle:lifecycle-common-java8:$versions.lifecycle"
 }
 

--- a/powermenu/src/main/res/layout/layout_power_menu.xml
+++ b/powermenu/src/main/res/layout/layout_power_menu.xml
@@ -6,14 +6,12 @@
   android:layout_height="wrap_content"
   android:focusable="true">
 
-  <androidx.cardview.widget.CardView
+  <com.google.android.material.card.MaterialCardView
     android:id="@+id/power_menu_card"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_margin="5dp"
-    android:clipToPadding="false"
-    app:cardCornerRadius="5dp"
-    app:cardElevation="5dp">
+    android:clipToPadding="false" >
 
     <ListView
       android:id="@+id/power_menu_listView"
@@ -29,6 +27,6 @@
       tools:ignore="UnusedAttribute"
       tools:listitem="@layout/item_power_menu" />
 
-  </androidx.cardview.widget.CardView>
+  </com.google.android.material.card.MaterialCardView>
 
 </FrameLayout>


### PR DESCRIPTION
## Guidelines
Allows the developer to add a stroke to the PowerMenu as shown in the demo and screenshot
![Screenshot_1601567468](https://user-images.githubusercontent.com/2768618/94832853-59edbe80-0406-11eb-9214-b8ba162f3f95.png)


### Types of changes
What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) MaterialCardView forces the application theme to extend one of `Theme.MaterialComponents` theme. If this too much of a breaking change I could make a MaterialPowerMenu

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.