### PR TITLE
strict mode violation exception prevention

### DIFF
--- a/powermenu/src/main/java/com/skydoves/powermenu/MenuPreferenceManager.java
+++ b/powermenu/src/main/java/com/skydoves/powermenu/MenuPreferenceManager.java
@@ -27,8 +27,14 @@ class MenuPreferenceManager {
   private final SharedPreferences sharedPreferences;
 
   private MenuPreferenceManager(Context context) {
-    sharedPreferences =
-        context.getSharedPreferences("com.skydoves.powermenu", Context.MODE_PRIVATE);
+    // Temporarily allow disk writes to avoid Strict mode exception 
+    StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskReads();
+    StrictMode.allowThreadDiskWrites();
+    try {
+      sharedPreferences = context.getSharedPreferences("com.skydoves.powermenu", Context.MODE_PRIVATE);
+    } finally {
+      StrictMode.setThreadPolicy(oldPolicy);
+    }
   }
 
   /**


### PR DESCRIPTION
Please complete the following information:

Library Version 2.2.0
Android 11.0
Describe the Bug:

Using the CustomPowerMenu.Builder and having Strict mode enabled in our Android app we get StrictMode policy violation; ~duration=453 ms: android.os.strictmode.DiskReadViolation exception when trying to inflate our view

Expected Behavior:

Is it possible to provide a way of using for the CustomPowerMenu.Builder which uses AbstractPowerMenu which uses MenuPreferenceManager but NOT read or write to sharedPrefs from within MenuPreferenceManager as it currently stands, so as to avoid the StrictMode policy violation; ~duration=453 ms: android.os.strictmode.DiskReadViolation