### PR TITLE
Fix focus state

### DIFF
--- a/app/src/main/java/com/skydoves/powermenudemo/PowerMenuUtils.java
+++ b/app/src/main/java/com/skydoves/powermenudemo/PowerMenuUtils.java
@@ -21,10 +21,7 @@ import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
 import android.view.Gravity;
-import androidx.appcompat.view.ContextThemeWrapper;
-import androidx.core.content.ContextCompat;
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleOwner;
+
 import com.skydoves.powermenu.CircularEffect;
 import com.skydoves.powermenu.CustomPowerMenu;
 import com.skydoves.powermenu.MenuAnimation;
@@ -35,6 +32,11 @@ import com.skydoves.powermenu.PowerMenuItem;
 import com.skydoves.powermenudemo.customs.adapters.CenterMenuAdapter;
 import com.skydoves.powermenudemo.customs.adapters.CustomDialogMenuAdapter;
 import com.skydoves.powermenudemo.customs.items.NameCardMenuItem;
+
+import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.core.content.ContextCompat;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
 
 public class PowerMenuUtils {
 
@@ -121,13 +123,17 @@ public class PowerMenuUtils {
       OnMenuItemClickListener<String> onMenuItemClickListener) {
     return new CustomPowerMenu.Builder<>(context, new CenterMenuAdapter())
         .addItem("You need to login!")
+        .addItem("You need to login2!")
+        .addItem("You need to login3!")
         .setLifecycleOwner(lifecycleOwner)
         .setAnimation(MenuAnimation.ELASTIC_CENTER)
-        .setMenuRadius(10f)
-        .setMenuShadow(10f)
+        .setMenuRadius(context.getResources().getDimensionPixelSize(R.dimen.menu_corner_radius))
+        .setMenuShadow(context.getResources().getDimensionPixelSize(R.dimen.menu_elevation))
+        .setIsMaterial(true)
         .setFocusable(true)
+        .setAutoDismiss(true)
+        .setShowBackground(false)
         .setOnMenuItemClickListener(onMenuItemClickListener)
-        .setOnBackgroundClickListener(view -> {})
         .build();
   }
 

--- a/app/src/main/java/com/skydoves/powermenudemo/PowerMenuUtils.java
+++ b/app/src/main/java/com/skydoves/powermenudemo/PowerMenuUtils.java
@@ -21,7 +21,10 @@ import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
 import android.view.Gravity;
-
+import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.core.content.ContextCompat;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
 import com.skydoves.powermenu.CircularEffect;
 import com.skydoves.powermenu.CustomPowerMenu;
 import com.skydoves.powermenu.MenuAnimation;
@@ -32,11 +35,6 @@ import com.skydoves.powermenu.PowerMenuItem;
 import com.skydoves.powermenudemo.customs.adapters.CenterMenuAdapter;
 import com.skydoves.powermenudemo.customs.adapters.CustomDialogMenuAdapter;
 import com.skydoves.powermenudemo.customs.items.NameCardMenuItem;
-
-import androidx.appcompat.view.ContextThemeWrapper;
-import androidx.core.content.ContextCompat;
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleOwner;
 
 public class PowerMenuUtils {
 

--- a/powermenu/src/main/java/com/skydoves/powermenu/AbstractPowerMenu.java
+++ b/powermenu/src/main/java/com/skydoves/powermenu/AbstractPowerMenu.java
@@ -259,6 +259,7 @@ public abstract class AbstractPowerMenu<E, T extends MenuBaseAdapter<E>>
   public void setFocusable(boolean focusable) {
     this.menuWindow.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
     this.menuWindow.setOutsideTouchable(!focusable);
+    menuWindow.setFocusable(focusable);
   }
 
   /**

--- a/powermenu/src/main/res/layout/layout_material_power_menu_library_skydoves.xml
+++ b/powermenu/src/main/res/layout/layout_material_power_menu_library_skydoves.xml
@@ -17,8 +17,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="wrap_content"
-  android:layout_height="wrap_content"
-  android:focusable="true">
+  android:layout_height="wrap_content" >
 
   <com.google.android.material.card.MaterialCardView
     android:id="@+id/power_menu_card"

--- a/powermenu/src/main/res/layout/layout_power_menu_library_skydoves.xml
+++ b/powermenu/src/main/res/layout/layout_power_menu_library_skydoves.xml
@@ -18,8 +18,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="wrap_content"
-  android:layout_height="wrap_content"
-  android:focusable="true">
+  android:layout_height="wrap_content">
 
   <androidx.cardview.widget.CardView
     android:id="@+id/power_menu_card"


### PR DESCRIPTION
### 🎯 Goal
When launching a menu, it currently does get focus which makes it impossible to access when using keyboard navigation

### 🛠 Implementation details
I simply set the window to be focusable

### ✍️ Explain examples
Example is no navigable through keyboard when using `.isFocusable`

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```bash
$ ./gradlew spotlessApply
```

Then dump binary APIs of this library that is public in sense of Kotlin visibilities and ensures that the public binary API wasn't changed in a way that makes this change binary incompatible.

```bash
./gradlew apiDump
```

Please correct any failures before requesting a review.

## Code reviews
All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more information on using pull requests.
